### PR TITLE
Add prepublish and postpublish scripts to ensure proper deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "testWithCoverage": "jest --coverage",
     "lint": "eslint src tests --ext .ts",
     "lint:fix": "eslint src tests --ext .ts --fix",
-    "prepublish": "rm -rf dist/ && npm run-script build"
+    "prepublish": "rm -rf dist/ && npm run-script build",
+    "postpublish": "npm logout"
   },
   "keywords": [
     "kintone"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "jest",
     "testWithCoverage": "jest --coverage",
     "lint": "eslint src tests --ext .ts",
-    "lint:fix": "eslint src tests --ext .ts --fix"
+    "lint:fix": "eslint src tests --ext .ts --fix",
+    "prepublish": "rm -rf dist/ && npm run-script build"
   },
   "keywords": [
     "kintone"


### PR DESCRIPTION
I published some old files that remained in `dist/` on my PC by accident.
I guess that's why the latest `kintone-query-builder-js` prints "@parseValue" to the window console.

This PR ensures the clean build before `npm publish`.

I also added `npm logout` at postpublish to avoid an accident.
https://qiita.com/sadnessOjisan/items/3069e79038c961458ba2